### PR TITLE
Migrates android gradle configuration for built in kotlin

### DIFF
--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # FFmpegKit Extended Flutter Plugin CHANGELOG
 
+## Version 0.5.3
+
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates Android Gradle configuration for built-in Kotlin (AGP 9+) with an AGP 8 fallback.
+- Removes Java 17 toolchain requirement that blocked builds with only Java 21 installed.
+
 ## Version 0.5.2
 
 - Fix Apple Swift Package Manager configuration

--- a/flutter/android/build.gradle.kts
+++ b/flutter/android/build.gradle.kts
@@ -4,35 +4,20 @@ import java.util.Properties
 group = "com.akashskypatel.ffmpeg_kit_extended_flutter"
 version = "1.0-SNAPSHOT"
 
-buildscript {
-    val kotlinVersion = "2.2.20"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.11.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 plugins {
     id("com.android.library")
-    id("kotlin-android")
+}
+
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
 }
 
 fun resolveStagedClassesJar(): File? {
     val appRoot = project.rootProject.projectDir.parentFile
     val propsFile = File(appRoot, ".dart_tool/hooks_runner/shared/ffmpeg_kit_extended_flutter/build/android_config/paths.properties")
-    
+
     if (!propsFile.exists()) {
         logger.warn("FFmpegKit: paths.properties not found at ${propsFile.absolutePath}. This is expected on the first build.")
         return null
@@ -41,7 +26,7 @@ fun resolveStagedClassesJar(): File? {
     val props = Properties()
     propsFile.inputStream().use { props.load(it) }
     val path = props.getProperty("classes_jar") ?: return null
-    
+
     val jarFile = File(path)
     return if (jarFile.exists()) jarFile else null
 }
@@ -54,10 +39,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlin {
-        jvmToolchain(17)
     }
 
     sourceSets {
@@ -102,12 +83,16 @@ android {
     }
 }
 
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
 dependencies {
-    // Reference the absolute path directly
     val appRoot = project.rootProject.projectDir.parentFile
     logger.info("FFmpegKit: App root is ${appRoot.absolutePath}")
     val stagedJarPath = "${appRoot}/.dart_tool/hooks_runner/shared/ffmpeg_kit_extended_flutter/build/android_config/classes.jar"
-    
-    // Use files() directly. Gradle will check for the file at execution time.
+
     implementation(files(stagedJarPath))
 }

--- a/flutter/example/android/app/build.gradle.kts
+++ b/flutter/example/android/app/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
 }
 
 android {
@@ -12,10 +17,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -30,6 +31,12 @@ android {
         release {
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/flutter/example/android/gradle.properties
+++ b/flutter/example/android/gradle.properties
@@ -6,3 +6,5 @@ kotlin.parallel.tasks.parallelism=false
 
 # Optional: Limits the daemon's lifespan to prevent memory-leak related corruption
 org.gradle.daemon.idletimeout=60000
+android.builtInKotlin=false
+android.newDsl=false

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -394,7 +394,7 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _pickTranscodeFile() async {
-    final result = await FilePicker.platform.pickFiles(type: FileType.video);
+    final result = await FilePicker.pickFiles(type: FileType.video);
     if (result != null && result.files.single.path != null) {
       final pickedPath = result.files.single.path!;
       final pickedDir = path.dirname(pickedPath);
@@ -859,7 +859,7 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _pickProbeFile() async {
-    final result = await FilePicker.platform.pickFiles();
+    final result = await FilePicker.pickFiles();
     if (result != null && result.files.single.path != null) {
       setState(() {
         _selectedProbePath = result.files.single.path;

--- a/flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,14 +7,12 @@ import Foundation
 
 import ffmpeg_kit_extended_flutter
 import file_picker
-import path_provider_foundation
 import screen_retriever_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FfmpegKitExtendedFlutterPlugin.register(with: registry.registrar(forPlugin: "FfmpegKitExtendedFlutterPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: "none"
 version: 0.5.2+1
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -18,7 +18,7 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   path: ^1.9.1
-  file_picker: ^10.3.10
+  file_picker: ^11.0.2
   android_media_store: ^0.0.1
   permission_handler: ^12.0.1
   path_provider: ^2.1.5

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/akashskypatel/ffmpeg-kit-extended
 issue_tracker: https://github.com/akashskypatel/ffmpeg-kit-extended/issues
 homepage: https://github.com/akashskypatel/ffmpeg-kit-extended
 documentation: https://github.com/akashskypatel/ffmpeg-kit-extended/tree/master/flutter/doc
-version: 0.5.2
+version: 0.5.3
 
 topics:
   - ffmpeg
@@ -14,8 +14,8 @@ topics:
   - ffmpeg-kit
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=1.10.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Migrates the Android Gradle configuration for `ffmpeg_kit_extended_flutter` to support Flutter 3.44’s built-in Kotlin changes (AGP 9+), while keeping an AGP 8 fallback for existing apps.

**Root cause:** The plugin’s `android/build.gradle.kts` used `kotlin { jvmToolchain(17) }`, which required a Java 17 installation. Builds failed on machines with only Java 21 installed (e.g. `Cannot find a Java installation matching {languageVersion=17}`).

**Changes:**
- Remove the legacy `buildscript` block and explicit Kotlin Gradle Plugin (KGP) classpath from the plugin
- Apply KGP only when AGP &lt; 9; on AGP 9+, rely on built-in Kotlin
- Replace `jvmToolchain(17)` / `kotlinOptions` with `compilerOptions { jvmTarget = JVM_17 }`
- Bump minimum SDK to Flutter 3.44 / Dart 3.12 (required for the new Kotlin DSL)
- Update the example app to match the same Gradle pattern
- Upgrade `file_picker` to `^11.0.2` and migrate to the static `FilePicker.pickFiles()` API
- Release as **0.5.3**

**Remaining warnings (out of scope for this PR):**
- `android_media_store` (0.0.3) still applies KGP — no migrated version on pub.dev
- `file_picker` 11.x still applies KGP on AGP 8; it is AGP 9–ready when the host app upgrades

## Related Issues

<!-- Link any GitHub issue numbers here, e.g. fixed #123 -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chore (refactoring, dependency updates, etc.)

**Breaking:** Minimum Flutter SDK raised to `>=3.44.0` and Dart to `>=3.12.0`.

## How Has This Been Tested?

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual verification

**Manual verification:**
- `flutter clean && flutter pub get && flutter build apk --debug` in `flutter/example/` — **passed**
- Confirmed `ffmpeg_kit_extended_flutter` no longer appears in Flutter’s KGP plugin warning list
- Verified build succeeds on macOS with Java 21 only (no Java 17 toolchain required)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

**Notes on unchecked items:**
- **Warnings:** KGP warnings remain for `android_media_store` and `file_picker` (AGP 8); not introduced by this plugin
- **Documentation:** CHANGELOG updated; no separate docs changes needed
- **Tests:** No new automated tests; fix is Gradle/build configuration only