### PR TITLE
Guard the build hook against the assetless invocation

### DIFF
--- a/flutter/hook/build.dart
+++ b/flutter/hook/build.dart
@@ -26,6 +26,10 @@ class ConfigResult {
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
+    // Flutter fires an assetless hook invocation (build_asset_types: []) with no
+    // code config present. input.config.code throws on it, so bail early when no
+    // code assets are requested. See HookConfig.buildCodeAssets.
+    if (!input.config.buildCodeAssets) return;
     final packageName = input.packageName;
     targetOS = input.config.code.targetOS;
     targetArch = input.config.code.targetArchitecture;


### PR DESCRIPTION
Hey! This fixes #16.

The build hook reads `input.config.code` on every invocation, but Flutter fires one with `build_asset_types: []` and no code config, so `.code` throws "Null check operator used on a null value" and fails the whole build (exit 255) even though the native binary bundles fine.

This bails out early when no code assets are requested, using the `buildCodeAssets` flag the `code_assets` API documents for exactly this case.

Tested on an Android debug build (Dart 3.12): the crash is gone, the build goes green and the app launches.
