### PR TITLE
Export StreamInformation and ChapterInformation from the barrel

### DIFF
--- a/flutter/lib/ffmpeg_kit_extended_flutter.dart
+++ b/flutter/lib/ffmpeg_kit_extended_flutter.dart
@@ -28,6 +28,7 @@ export 'src/callback_manager.dart'
         FFmpegStatisticsCallback,
         FFprobeSessionCompleteCallback,
         FFplaySessionCompleteCallback;
+export 'src/chapter_information.dart';
 export 'src/ffmpeg_kit.dart';
 export 'src/ffmpeg_kit_config.dart';
 export 'src/ffmpeg_kit_extended.dart';
@@ -49,3 +50,4 @@ export 'src/session_queue_manager.dart'
     show SessionQueueManager, SessionCancelledException;
 export 'src/signal.dart';
 export 'src/statistics.dart';
+export 'src/stream_information.dart';


### PR DESCRIPTION
Hey! This fixes #15.

`StreamInformation` and `ChapterInformation` are the element types of the public `MediaInformation.streams` and `.chapters`, but they aren't exported from the barrel. So anything that reads those lists has to import them from `src/`, which trips the `implementation_imports` lint.

This adds the two `export` lines so they come through the public API the same way `MediaInformation` already does.
