### PR TITLE
fix(android): align native dummy lib to 16 KB page size

### DIFF
--- a/flutter/android/src/main/cpp/CMakeLists.txt
+++ b/flutter/android/src/main/cpp/CMakeLists.txt
@@ -1,2 +1,8 @@
 cmake_minimum_required(VERSION 3.4.1)
 add_library(ffmpeg_kit_extended_dummy SHARED dummy.cpp)
+
+# Align ELF LOAD segments to 16 KB so the library is compatible with 16 KB
+# page-size Android devices (required by Google Play for apps targeting
+# Android 15+). NDK r28+ does this by default; adding the flag explicitly keeps
+# older NDKs (r27 and below) compliant as well.
+target_link_options(ffmpeg_kit_extended_dummy PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
## Problem

Apps using `ffmpeg_kit_extended_flutter` fail Google Play's **16 KB page-size compatibility** check on Android. The Android Studio APK Analyzer reports:

> APK does not support 16 KB devices

The offending library is `libffmpeg_kit_extended_dummy.so` (the small dummy library compiled from `flutter/android/src/main/cpp/CMakeLists.txt` to force packaging of `libc++_shared.so`). Its ELF `LOAD` segments are aligned to **4 KB** instead of 16 KB:

> 4 KB LOAD section alignment, but 16 KB required

All other shipped libraries (`libffmpegkit.so`, `libc++_shared.so`, etc.) are already 16 KB aligned, so this tiny dummy library is the only thing breaking the requirement.

Starting **November 2025**, Google Play requires all apps targeting Android 15+ (API 35) to support 16 KB page sizes, so this currently blocks releases.

## Fix

Add an explicit linker flag so the dummy library's segments are aligned to 16 KB:

```cmake
target_link_options(ffmpeg_kit_extended_dummy PRIVATE "-Wl,-z,max-page-size=16384")
```

This guarantees 16 KB alignment regardless of the consumer's NDK version. NDK r28+ already defaults to this, but r27 and below do not, so the explicit flag keeps everyone compliant.

## Testing

- Built a release APK of an app consuming the patched plugin.
- Verified in the APK Analyzer that `libffmpeg_kit_extended_dummy.so` now reports 16 KB alignment and the "APK does not support 16 KB devices" warning is gone.

## Notes

- Single-line change, no behavior impact (the library only exists to pull in `libc++_shared.so`).
- References: [Android 16 KB page size support](https://developer.android.com/guide/practices/page-sizes).
