### PR TITLE
fix: preserve FFmpeg, FFprobe, and FFplay arguments

### DIFF
--- a/.github/workflows/flutter_example_ci.yaml
+++ b/.github/workflows/flutter_example_ci.yaml
@@ -27,6 +27,11 @@ on:
       - "!react-native/**"
       - "!flutter/doc/**"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - "flutter/**"
       - ".github/workflows/flutter_example_ci.yaml"
@@ -54,6 +59,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -190,6 +196,7 @@ jobs:
           retention-days: 7
 
   analyze:
+    if: github.event.pull_request.draft == false
     name: Static Analysis
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/flutter_example_ci.yaml
+++ b/.github/workflows/flutter_example_ci.yaml
@@ -24,6 +24,7 @@ on:
       - "**.cc"
       - "**.podspec"
       - "!**.md"
+      - "!react-native/**"
       - "!flutter/doc/**"
   pull_request:
     paths:
@@ -44,6 +45,7 @@ on:
       - "**.cpp"
       - "**.cc"
       - "!**.md"
+      - "!react-native/**"
       - "!flutter/doc/**"
 
 concurrency:

--- a/.github/workflows/react_native_example_ci.yaml
+++ b/.github/workflows/react_native_example_ci.yaml
@@ -11,6 +11,11 @@ on:
       - "!flutter/**"
       - ".github/workflows/react_native_example_ci.yaml"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - "react-native/**"
       - "!flutter/**"
@@ -25,6 +30,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/react_native_example_ci.yaml
+++ b/.github/workflows/react_native_example_ci.yaml
@@ -8,10 +8,12 @@ on:
       - master
     paths:
       - "react-native/**"
+      - "!flutter/**"
       - ".github/workflows/react_native_example_ci.yaml"
   pull_request:
     paths:
       - "react-native/**"
+      - "!flutter/**"
       - ".github/workflows/react_native_example_ci.yaml"
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Apple libraries (iOS/macOS/tvOS) are universal fatlibs and include both ARM64 an
 > - **`libopenvino`** and **`libtensorflow`** are only available on Desktop builds (`MacOS`, `Linux`, and `Windows`).
 > - **`libtorch`** is only available on `Linux` and `MacOs` builds (`Windows` not supported due ABI mismatch).
 > - **`libonnxruntime`** is not available on `x86_64` `MacOS`.
+> - Only CPU AI libraries are vendored with pre-built bundles. GPU libraries must be custom deployed.
 
 | Bundle Key | Description                          |
 | ---------- | ------------------------------------ |

--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Version 0.6.0
 
 - Upgrade FFmpeg version to v9.0.1
+- Fix media-information sessions for paths containing whitespace or literal
+  quote characters by passing file/URI values as native argv entries.
+- Add `MediaInformationSession.fromArguments` and `createWithArguments` for
+  quote-safe custom ffprobe arguments.
+- Add `FFplaySession.fromArguments` / `createFromArguments` and an FFplayKit
+  argv factory; FFmpeg and FFplay argv sessions now remain tokenized natively.
 
 ## Version 0.5.13
 

--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # FFmpegKit Extended Flutter Plugin CHANGELOG
 
+## Version 0.6.2
+
+- Preserve FFmpeg, FFprobe, and FFplay session arguments as argv all the way into their embedded CLI runtimes to fix argument parsing bug exposed by quotes in commands.
+- Fix `debug` build for macOS, iOS, Windows and Linux.
+
 ## Version 0.6.0
 
 - Upgrade FFmpeg version to v9.0.1

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -166,6 +166,7 @@ You will have to update your app's minimum requirements on your own to match the
 > - **`libopenvino`** and **`libtensorflow`** are only available on Desktop builds (`MacOS`, `Linux`, and `Windows`).
 > - **`libtorch`** is only available on `Linux` and `MacOs` builds (`Windows` not supported due ABI mismatch).
 > - **`libonnxruntime`** is not available on `x86_64` `MacOS`.
+> - Only CPU AI libraries are vendored with pre-built bundles. GPU libraries must be custom deployed.
 
 | Feature   | Base | Audio | Video | Video+Hardware | Full |
 | --------- | ---- | ----- | ----- | -------------- | ---- |

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/akashskypatel/ffmpeg-kit-extended
 issue_tracker: https://github.com/akashskypatel/ffmpeg-kit-extended/issues
 homepage: https://github.com/akashskypatel/ffmpeg-kit-extended
 publish_to: "none"
-version: 0.6.0+1
+version: 0.6.2+1
 
 environment:
   sdk: ">=3.12.0 <4.0.0"

--- a/flutter/hook/build.dart
+++ b/flutter/hook/build.dart
@@ -11,7 +11,7 @@ import 'package:yaml/yaml.dart';
 const String _baseUrlTemplate =
     "https://github.com/akashskypatel/ffmpeg-kit-builders/releases/download";
 const _validTypes = ['debug', 'base', 'full', 'audio', 'video', 'video_hw'];
-const String version = "0.11.0";
+const String version = "0.11.1";
 const String _extractMarkerFileName = '.extract_complete';
 
 void _log(String message) => stderr.writeln('FFmpegKit [Build Hook]: $message');
@@ -293,7 +293,11 @@ Future<FFmpegArtifact?> _resolveArtifact(
       url = "$_baseUrlTemplate/$tag/$filename";
     } else if (targetOS == OS.iOS || targetOS == OS.macOS) {
       final parts = ['bundle', currentType, platformName, 'universal'];
-      if (type != 'debug' && small) parts.add('small');
+      if (type == 'debug') {
+        parts.add('debug');
+      } else if (small) {
+        parts.add('small');
+      }
       parts.add(license);
       filename = "${parts.join('-')}.xcframework.zip";
       final tag = "v$version-$platformName";
@@ -304,7 +308,11 @@ Future<FFmpegArtifact?> _resolveArtifact(
           ? 'x86_64'
           : (targetArch == Architecture.arm64 ? 'arm64' : 'x86_64');
       final parts = ['bundle', currentType, platformName, archStr, 'shared'];
-      if (type != 'debug' && small) parts.add('small');
+      if (type == 'debug') {
+        parts.add('debug');
+      } else if (small) {
+        parts.add('small');
+      }
       parts.add(license);
       filename = "${parts.join('-')}.zip";
       final tag = "v$version-$platformName";

--- a/flutter/lib/src/ffplay_kit.dart
+++ b/flutter/lib/src/ffplay_kit.dart
@@ -102,6 +102,33 @@ class FFplayKit {
     return _activeFFplaySession!;
   }
 
+  /// Creates a new [FFplaySession] from pre-tokenized [arguments].
+  static Future<FFplaySession> createSessionFromArguments(
+    List<String> arguments, {
+    FFplaySessionCompleteCallback? onComplete,
+    callback_manager.FFmpegLogCallback? onLog,
+  }) async {
+    _sessionCompleter = Completer<void>();
+
+    void wrappedCallback(FFplaySession session) {
+      onComplete?.call(session);
+      if (_activeFFplaySession == session) {
+        _activeFFplaySession = null;
+        _sessionCompleter?.complete();
+        _sessionCompleter = null;
+      }
+    }
+
+    _activeFFplaySession = FFplaySession.createGlobalFromArguments(
+      arguments,
+      completeCallback: wrappedCallback,
+    );
+    if (onLog != null) {
+      _activeFFplaySession!.setLogCallback(onLog);
+    }
+    return _activeFFplaySession!;
+  }
+
   /// Cancels a [session] if it is currently running.
   static void cancel(FFplaySession session) => session.cancel();
 

--- a/flutter/lib/src/ffplay_session.dart
+++ b/flutter/lib/src/ffplay_session.dart
@@ -154,6 +154,51 @@ class FFplaySession extends Session {
     _registered = true;
   }
 
+  /// Creates a new [FFplaySession] from pre-tokenized [arguments].
+  ///
+  /// Arguments are passed to the native layer verbatim, so paths and values
+  /// containing whitespace or literal quotes require no caller-side escaping.
+  FFplaySession.fromArguments(
+    List<String> arguments, {
+    FFplaySessionCompleteCallback? completeCallback,
+    int timeout = 500,
+  }) : _timeout = timeout {
+    FFmpegKitExtended.requireInitialized();
+    if (arguments.isEmpty) {
+      throw ArgumentError.value(arguments, 'arguments', 'must not be empty');
+    }
+
+    final argv = calloc<Pointer<Char>>(arguments.length);
+    final nativeStrings = <Pointer<Utf8>>[];
+    try {
+      for (var i = 0; i < arguments.length; i++) {
+        final nativeString = arguments[i].toNativeUtf8(allocator: calloc);
+        nativeStrings.add(nativeString);
+        argv[i] = nativeString.cast<Char>();
+      }
+
+      handle = ffmpeg.ffplay_kit_create_session_from_argv(
+        arguments.length,
+        argv,
+      );
+      if (handle == nullptr) {
+        throw StateError('Failed to create FFplay session from arguments.');
+      }
+      command = FFmpegKitExtended.argumentsToString(arguments);
+      sessionId = ffmpeg.ffmpeg_kit_session_get_session_id(handle);
+      registerFinalizer();
+    } finally {
+      for (final nativeString in nativeStrings) {
+        calloc.free(nativeString);
+      }
+      calloc.free(argv);
+    }
+
+    _completeCallback = completeCallback;
+    CallbackManager().registerFFplaySession(this);
+    _registered = true;
+  }
+
   // ---------------------------------------------------------------------------
   // Static helpers (deprecated wrappers for API compatibility)
   // ---------------------------------------------------------------------------
@@ -179,6 +224,28 @@ class FFplaySession extends Session {
     int timeout = 500,
   }) => FFplaySession(
     command,
+    timeout: timeout,
+    completeCallback: completeCallback,
+  );
+
+  /// Creates an FFplay session from pre-tokenized arguments.
+  static FFplaySession createFromArguments(
+    List<String> arguments, {
+    FFplaySessionCompleteCallback? completeCallback,
+    int timeout = 500,
+  }) => FFplaySession.fromArguments(
+    arguments,
+    timeout: timeout,
+    completeCallback: completeCallback,
+  );
+
+  /// Internal argv factory used by [FFplayKit] for global tracking.
+  static FFplaySession createGlobalFromArguments(
+    List<String> arguments, {
+    FFplaySessionCompleteCallback? completeCallback,
+    int timeout = 500,
+  }) => FFplaySession.fromArguments(
+    arguments,
     timeout: timeout,
     completeCallback: completeCallback,
   );

--- a/flutter/lib/src/generated/ffmpeg_kit_bindings.dart
+++ b/flutter/lib/src/generated/ffmpeg_kit_bindings.dart
@@ -1209,6 +1209,25 @@ external MediaInformationSessionHandle media_information_create_session(
   ffi.Pointer<ffi.Char> command,
 );
 
+/// Creates a new MediaInformation session from an argument array.
+///
+/// Arguments are passed as individual values without command-string reparsing.
+///
+/// @param argc the number of arguments
+/// @param argv the argument array
+/// @return the MediaInformation session handle
+@ffi.Native<
+  MediaInformationSessionHandle Function(
+    ffi.Int,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+  )
+>()
+external MediaInformationSessionHandle
+media_information_create_session_from_argv(
+  int argc,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> argv,
+);
+
 /// Creates a new MediaInformation session with the given command.
 ///
 /// @param command the MediaInformation command to execute

--- a/flutter/lib/src/media_information_session.dart
+++ b/flutter/lib/src/media_information_session.dart
@@ -44,8 +44,19 @@ class MediaInformationSession extends FFprobeSession {
   // ---------------------------------------------------------------------------
 
   static const String _defaultCommandPrefix = '-v error -hide_banner';
-  static const String _defaultCommand =
-      '-v error -hide_banner -print_format json -show_format -show_streams -show_chapters -i';
+  static const List<String> _defaultCommandPrefixArguments = [
+    '-v',
+    'error',
+    '-hide_banner',
+  ];
+  static const List<String> _defaultMediaInformationArguments = [
+    '-print_format',
+    'json',
+    '-show_format',
+    '-show_streams',
+    '-show_chapters',
+    '-i',
+  ];
 
   // ---------------------------------------------------------------------------
   // Callback accessors / mutators
@@ -159,6 +170,65 @@ class MediaInformationSession extends FFprobeSession {
   // Named constructors
   // ---------------------------------------------------------------------------
 
+  /// Creates a [MediaInformationSession] from individual ffprobe [arguments].
+  ///
+  /// The default `-v error -hide_banner` arguments are prepended. Each supplied
+  /// argument is passed to the native layer verbatim, so callers do not need to
+  /// quote or escape whitespace or literal quote characters inside values.
+  MediaInformationSession.fromArguments(
+    List<String> arguments, {
+    MediaInformationSessionCompleteCallback? completeCallback,
+    int timeout = 500,
+  }) : _timeout = timeout,
+       super.internal() {
+    FFmpegKitExtended.requireInitialized();
+    final finalArguments = <String>[
+      ..._defaultCommandPrefixArguments,
+      ...arguments,
+    ];
+    command = finalArguments.join(' ');
+
+    using((Arena arena) {
+      final argv = arena<Pointer<Char>>(finalArguments.length);
+      for (var i = 0; i < finalArguments.length; i++) {
+        argv[i] = finalArguments[i]
+            .toNativeUtf8(allocator: arena)
+            .cast<Char>();
+      }
+
+      try {
+        handle = ffmpeg.media_information_create_session_from_argv(
+          finalArguments.length,
+          argv,
+        );
+      } catch (e, st) {
+        log(
+          'MediaInformationSession.fromArguments: error creating session '
+          'media_information_create_session_from_argv $command',
+          error: e,
+          stackTrace: st,
+        );
+        rethrow;
+      }
+    });
+
+    try {
+      sessionId = ffmpeg.ffmpeg_kit_session_get_session_id(handle);
+    } catch (e, st) {
+      log(
+        'MediaInformationSession.fromArguments: error getting session id '
+        'for ffmpeg_kit_session_get_session_id $command',
+        error: e,
+        stackTrace: st,
+      );
+      rethrow;
+    }
+    registerFinalizer();
+
+    _mediaInfoCompleteCallback = completeCallback;
+    ensureRegistered();
+  }
+
   /// Restores a [MediaInformationSession] from a native [handle].
   MediaInformationSession.fromHandle(Pointer<Void> handle, String command)
     : _timeout = 500,
@@ -182,102 +252,32 @@ class MediaInformationSession extends FFprobeSession {
   }
 
   /// Creates a [MediaInformationSession] for a local [file].
-  MediaInformationSession.fromFile(
+  ///
+  /// The file path is passed as one native argument, so whitespace and literal
+  /// quote characters in the filename require no caller-side escaping.
+  factory MediaInformationSession.fromFile(
     File file, {
     MediaInformationSessionCompleteCallback? completeCallback,
     int timeout = 500,
-  }) : _timeout = timeout,
-       super.internal() {
-    FFmpegKitExtended.requireInitialized();
-    final finalCommand = '$_defaultCommand ${file.path}';
-    command = finalCommand;
-
-    final cmdPtr = finalCommand.toNativeUtf8(allocator: calloc);
-    try {
-      try {
-        handle = ffmpeg.media_information_create_session(cmdPtr.cast());
-      } catch (e, st) {
-        log(
-          'MediaInformationSession.fromFile: error creating session media_information_create_session $finalCommand',
-          error: e,
-          stackTrace: st,
-        );
-        rethrow;
-      }
-      try {
-        sessionId = ffmpeg.ffmpeg_kit_session_get_session_id(handle);
-      } catch (e, st) {
-        log(
-          'MediaInformationSession.fromFile: error getting session id for ffmpeg_kit_session_get_session_id $finalCommand',
-          error: e,
-          stackTrace: st,
-        );
-        rethrow;
-      }
-      registerFinalizer();
-    } catch (e, st) {
-      log(
-        'MediaInformationSession.fromFile: failed to create session',
-        error: e,
-        stackTrace: st,
-      );
-      rethrow;
-    } finally {
-      calloc.free(cmdPtr);
-    }
-
-    _mediaInfoCompleteCallback = completeCallback;
-    ensureRegistered();
-  }
+  }) => MediaInformationSession.fromArguments(
+    [..._defaultMediaInformationArguments, file.path],
+    completeCallback: completeCallback,
+    timeout: timeout,
+  );
 
   /// Creates a [MediaInformationSession] for a network [uri].
-  MediaInformationSession.fromUri(
+  ///
+  /// The URI is passed as one native argument and is not reparsed as command
+  /// text.
+  factory MediaInformationSession.fromUri(
     Uri uri, {
     MediaInformationSessionCompleteCallback? completeCallback,
     int timeout = 500,
-  }) : _timeout = timeout,
-       super.internal() {
-    FFmpegKitExtended.requireInitialized();
-    final finalCommand = '$_defaultCommand ${uri.toString()}';
-    command = finalCommand;
-
-    final cmdPtr = finalCommand.toNativeUtf8(allocator: calloc);
-    try {
-      try {
-        handle = ffmpeg.media_information_create_session(cmdPtr.cast());
-      } catch (e, st) {
-        log(
-          'MediaInformationSession.fromUri: error creating session media_information_create_session $finalCommand',
-          error: e,
-          stackTrace: st,
-        );
-        rethrow;
-      }
-      try {
-        sessionId = ffmpeg.ffmpeg_kit_session_get_session_id(handle);
-      } catch (e, st) {
-        log(
-          'MediaInformationSession.fromUri: error getting session id for ffmpeg_kit_session_get_session_id $finalCommand',
-          error: e,
-          stackTrace: st,
-        );
-        rethrow;
-      }
-      registerFinalizer();
-    } catch (e, st) {
-      log(
-        'MediaInformationSession.fromUri: failed to create session',
-        error: e,
-        stackTrace: st,
-      );
-      rethrow;
-    } finally {
-      calloc.free(cmdPtr);
-    }
-
-    _mediaInfoCompleteCallback = completeCallback;
-    ensureRegistered();
-  }
+  }) => MediaInformationSession.fromArguments(
+    [..._defaultMediaInformationArguments, uri.toString()],
+    completeCallback: completeCallback,
+    timeout: timeout,
+  );
 
   // ---------------------------------------------------------------------------
   // Static factories
@@ -326,6 +326,17 @@ class MediaInformationSession extends FFprobeSession {
     int timeout = 500,
   }) => MediaInformationSession(
     command,
+    timeout: timeout,
+    completeCallback: completeCallback,
+  );
+
+  /// Creates a session from individual ffprobe [arguments].
+  static MediaInformationSession createWithArguments(
+    List<String> arguments, {
+    MediaInformationSessionCompleteCallback? completeCallback,
+    int timeout = 500,
+  }) => MediaInformationSession.fromArguments(
+    arguments,
     timeout: timeout,
     completeCallback: completeCallback,
   );

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/akashskypatel/ffmpeg-kit-extended
 issue_tracker: https://github.com/akashskypatel/ffmpeg-kit-extended/issues
 homepage: https://github.com/akashskypatel/ffmpeg-kit-extended
 documentation: https://github.com/akashskypatel/ffmpeg-kit-extended/tree/master/flutter/doc
-version: 0.6.0
+version: 0.6.2
 
 topics:
   - ffmpeg

--- a/react-native/CHANGELOG.md
+++ b/react-native/CHANGELOG.md
@@ -1,5 +1,14 @@
 # FFmpegKit Extended React Native Changelog
 
+## Version 0.6.2
+
+- Preserve FFmpeg, FFprobe, and FFplay session arguments as argv all the way into their embedded CLI runtimes to fix argument parsing bug exposed by quotes in commands.
+- Fix `debug` build for macOS, iOS, Windows and Linux.
+
+## Version 0.6.1
+
+- Update documentation
+
 ## Version 0.6.0
 
 - Upgrade FFmpeg version to v9.0.1

--- a/react-native/CHANGELOG.md
+++ b/react-native/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Version 0.6.0
 
 - Upgrade FFmpeg version to v9.0.1
+- Fix media-information probing for paths containing whitespace or literal quote characters by passing the input path as a native argv entry.
+- Preserve pre-tokenized FFmpeg and FFplay arguments across the TurboModule boundary instead of serializing them back into command strings.
+- Align command-string parsing with native compatibility semantics, including empty arguments and Windows/UNC backslash preservation.
 
 ## Version 0.5.13
 

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -87,6 +87,7 @@ React Native's legacy Native Module architecture.
 > - **`libopenvino`** and **`libtensorflow`** are only available on Desktop builds (`MacOS`, `Linux`, and `Windows`).
 > - **`libtorch`** is only available on `Linux` and `MacOs` builds (`Windows` not supported due ABI mismatch).
 > - **`libonnxruntime`** is only available on Desktop builds (`MacOS`, `Linux`, and `Windows`) but not supported on `x86_64` `MacOS`.
+> - Only CPU AI libraries are vendored with pre-built bundles. GPU libraries must be custom deployed.
 
 ## Bundle Sizes
 

--- a/react-native/cpp/FFmpegKitDynamicApi.cpp
+++ b/react-native/cpp/FFmpegKitDynamicApi.cpp
@@ -430,10 +430,59 @@ static double createSessionWith(const char *symbol, const std::string &command) 
   return static_cast<double>(id);
 }
 
+static double createSessionWithArguments(
+    const char *symbol, const std::vector<std::string> &arguments) {
+  ensureInitialized();
+  if (arguments.empty()) {
+    throw std::invalid_argument("FFmpegKit argument list must not be empty");
+  }
+
+  std::vector<const char *> argv;
+  argv.reserve(arguments.size());
+  for (const auto &argument : arguments) {
+    argv.push_back(argument.c_str());
+  }
+
+  using Fn = Handle (*)(int, const char **);
+  HandleGuard guard(resolve<Fn>(symbol)(static_cast<int>(argv.size()), argv.data()));
+  if (guard.handle == nullptr) {
+    throw std::runtime_error("Failed to create FFmpegKit session from arguments");
+  }
+  const auto id = sessionIdOf(guard.handle);
+  recordKnownSessionId(id);
+  return static_cast<double>(id);
+}
+
 double createFFmpegSession(const std::string &command) { return createSessionWith("ffmpeg_kit_create_session", command); }
+double createFFmpegSessionFromArguments(const std::vector<std::string> &arguments) { return createSessionWithArguments("ffmpeg_kit_create_session_from_argv", arguments); }
 double createFFprobeSession(const std::string &command) { return createSessionWith("ffprobe_kit_create_session", command); }
 double createFFplaySession(const std::string &command) { return createSessionWith("ffplay_kit_create_session", command); }
+double createFFplaySessionFromArguments(const std::vector<std::string> &arguments) { return createSessionWithArguments("ffplay_kit_create_session_from_argv", arguments); }
 double createMediaInformationSession(const std::string &command) { return createSessionWith("media_information_create_session", command); }
+
+double createMediaInformationSessionFromPath(const std::string &path) {
+  ensureInitialized();
+  const std::vector<std::string> arguments = {
+      "-v",            "error",          "-hide_banner",
+      "-print_format", "json",           "-show_format",
+      "-show_streams", "-show_chapters", "-i",
+      path};
+  std::vector<const char *> argv;
+  argv.reserve(arguments.size());
+  for (const auto &argument : arguments) {
+    argv.push_back(argument.c_str());
+  }
+
+  using Fn = Handle (*)(int, const char **);
+  HandleGuard guard(resolve<Fn>("media_information_create_session_from_argv")(
+      static_cast<int>(argv.size()), argv.data()));
+  if (guard.handle == nullptr) {
+    throw std::runtime_error("Failed to create FFmpegKit media information session");
+  }
+  const auto id = sessionIdOf(guard.handle);
+  recordKnownSessionId(id);
+  return static_cast<double>(id);
+}
 
 void executeSessionAsync(double sessionId, double timeoutMs) {
   ensureInitialized();

--- a/react-native/cpp/FFmpegKitDynamicApi.h
+++ b/react-native/cpp/FFmpegKitDynamicApi.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace ffmpegkit::bridge {
 
@@ -9,9 +10,12 @@ void initialize();
 std::string getBuildStamp();
 
 double createFFmpegSession(const std::string &command);
+double createFFmpegSessionFromArguments(const std::vector<std::string> &arguments);
 double createFFprobeSession(const std::string &command);
 double createFFplaySession(const std::string &command);
+double createFFplaySessionFromArguments(const std::vector<std::string> &arguments);
 double createMediaInformationSession(const std::string &command);
+double createMediaInformationSessionFromPath(const std::string &path);
 void executeSessionAsync(double sessionId, double timeoutMs);
 void cancelSession(double sessionId);
 

--- a/react-native/cpp/FFmpegKitExtendedImpl.cpp
+++ b/react-native/cpp/FFmpegKitExtendedImpl.cpp
@@ -11,9 +11,12 @@ void FFmpegKitExtendedImpl::initialize(jsi::Runtime &) { api::initialize(); }
 std::string FFmpegKitExtendedImpl::getBuildStamp(jsi::Runtime &) { return api::getBuildStamp(); }
 
 double FFmpegKitExtendedImpl::createFFmpegSession(jsi::Runtime &, std::string command) { return api::createFFmpegSession(command); }
+double FFmpegKitExtendedImpl::createFFmpegSessionFromArguments(jsi::Runtime &, std::vector<std::string> arguments) { return api::createFFmpegSessionFromArguments(arguments); }
 double FFmpegKitExtendedImpl::createFFprobeSession(jsi::Runtime &, std::string command) { return api::createFFprobeSession(command); }
 double FFmpegKitExtendedImpl::createFFplaySession(jsi::Runtime &, std::string command) { return api::createFFplaySession(command); }
+double FFmpegKitExtendedImpl::createFFplaySessionFromArguments(jsi::Runtime &, std::vector<std::string> arguments) { return api::createFFplaySessionFromArguments(arguments); }
 double FFmpegKitExtendedImpl::createMediaInformationSession(jsi::Runtime &, std::string command) { return api::createMediaInformationSession(command); }
+double FFmpegKitExtendedImpl::createMediaInformationSessionFromPath(jsi::Runtime &, std::string path) { return api::createMediaInformationSessionFromPath(path); }
 void FFmpegKitExtendedImpl::executeSessionAsync(jsi::Runtime &, double sessionId, double timeoutMs) { api::executeSessionAsync(sessionId, timeoutMs); }
 void FFmpegKitExtendedImpl::cancelSession(jsi::Runtime &, double sessionId) { api::cancelSession(sessionId); }
 

--- a/react-native/cpp/FFmpegKitExtendedImpl.h
+++ b/react-native/cpp/FFmpegKitExtendedImpl.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace facebook::react {
 
@@ -17,9 +18,12 @@ class FFmpegKitExtendedImpl
   std::string getBuildStamp(jsi::Runtime &rt);
 
   double createFFmpegSession(jsi::Runtime &rt, std::string command);
+  double createFFmpegSessionFromArguments(jsi::Runtime &rt, std::vector<std::string> arguments);
   double createFFprobeSession(jsi::Runtime &rt, std::string command);
   double createFFplaySession(jsi::Runtime &rt, std::string command);
+  double createFFplaySessionFromArguments(jsi::Runtime &rt, std::vector<std::string> arguments);
   double createMediaInformationSession(jsi::Runtime &rt, std::string command);
+  double createMediaInformationSessionFromPath(jsi::Runtime &rt, std::string path);
   void executeSessionAsync(jsi::Runtime &rt, double sessionId, double timeoutMs);
   void cancelSession(jsi::Runtime &rt, double sessionId);
 

--- a/react-native/example/ffmpeg-kit-extended.config.json
+++ b/react-native/example/ffmpeg-kit-extended.config.json
@@ -1,5 +1,5 @@
 {
-  "type": "base",
+  "type": "debug",
   "gpl": false,
   "small": true
 }

--- a/react-native/example/package.json
+++ b/react-native/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FFmpegKitExtendedExample",
-  "version": "0.6.1+1",
+  "version": "0.6.2+1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-kit-extended",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "React Native TurboModule bindings for FFmpegKit Extended",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/react-native/scripts/resolve-ffmpeg-kit-config.js
+++ b/react-native/scripts/resolve-ffmpeg-kit-config.js
@@ -79,7 +79,7 @@ function loadConfig(appRoot) {
     return {
       appRoot: resolvedAppRoot,
       configPath: null,
-      config: {...DEFAULT_CONFIG},
+      config: { ...DEFAULT_CONFIG },
       usedDefaultConfig: true,
     };
   }
@@ -98,7 +98,7 @@ function loadConfig(appRoot) {
   return {
     appRoot: path.dirname(configPath),
     configPath,
-    config: {...DEFAULT_CONFIG, ...parsed},
+    config: { ...DEFAULT_CONFIG, ...parsed },
     usedDefaultConfig: false,
   };
 }
@@ -107,7 +107,7 @@ function createCacheKey(value) {
   return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
 }
 
-function resolveConfig({appRoot, platform, architecture}) {
+function resolveConfig({ appRoot, platform, architecture }) {
   const targetPlatform = normalizePlatform(platform);
   const targetArchitecture = normalizeArchitecture(architecture);
   const loaded = loadConfig(appRoot);
@@ -159,7 +159,7 @@ function resolveConfig({appRoot, platform, architecture}) {
         filename = path.basename(value);
       }
       if (!filename) fail(`Could not determine a filename from ${value}`);
-      result.override = {kind: 'remote', value};
+      result.override = { kind: 'remote', value };
       result.filename = filename;
       result.url = value;
       result.cacheKey = createCacheKey(`remote:${value}`);
@@ -169,7 +169,7 @@ function resolveConfig({appRoot, platform, architecture}) {
     const resolvedPath = path.isAbsolute(value)
       ? path.normalize(value)
       : path.resolve(loaded.appRoot, value);
-    result.override = {kind: 'local', value, resolvedPath};
+    result.override = { kind: 'local', value, resolvedPath };
     result.filename = path.basename(resolvedPath);
     result.cacheKey = createCacheKey(`local:${resolvedPath}`);
     return result;
@@ -178,8 +178,11 @@ function resolveConfig({appRoot, platform, architecture}) {
   const currentType = type === 'debug' ? 'base' : type;
   if (targetPlatform === 'android') {
     const parts = ['bundle', currentType, 'shared'];
-    if (type === 'debug') parts.push('debug');
-    else if (small) parts.push('small');
+    if (type === 'debug') {
+      parts.push('debug');
+    } else if (small) {
+      parts.push('small');
+    }
     parts.push(license);
 
     const artifactId = parts.join('-');
@@ -201,8 +204,11 @@ function resolveConfig({appRoot, platform, architecture}) {
     targetPlatform === 'macos'
   ) {
     const parts = ['bundle', currentType, targetPlatform, 'universal'];
-    if (type === 'debug') parts.push('debug');
-    else if (small) parts.push('small');
+    if (type === 'debug') {
+      parts.push('debug');
+    } else if (small) {
+      parts.push('small');
+    }
     parts.push(license);
 
     result.artifact = parts.join('-');
@@ -219,8 +225,11 @@ function resolveConfig({appRoot, platform, architecture}) {
 
   const arch = targetArchitecture || 'x86_64';
   const parts = ['bundle', currentType, targetPlatform, arch, 'shared'];
-  if (type === 'debug') parts.push('debug');
-  else if (small) parts.push('small');
+  if (type === 'debug') {
+    parts.push('debug');
+  } else if (small) {
+    parts.push('small');
+  }
   parts.push(license);
 
   result.artifact = parts.join('-');

--- a/react-native/scripts/resolve-ffmpeg-kit-config.js
+++ b/react-native/scripts/resolve-ffmpeg-kit-config.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 
 const CONFIG_FILE_NAME = 'ffmpeg-kit-extended.config.json';
-const BINARY_VERSION = '0.11.0';
+const BINARY_VERSION = '0.11.1';
 const BASE_RELEASE_URL =
   'https://github.com/akashskypatel/ffmpeg-kit-builders/releases/download';
 const RELEASE_API_URL =
@@ -201,7 +201,8 @@ function resolveConfig({appRoot, platform, architecture}) {
     targetPlatform === 'macos'
   ) {
     const parts = ['bundle', currentType, targetPlatform, 'universal'];
-    if (type !== 'debug' && small) parts.push('small');
+    if (type === 'debug') parts.push('debug');
+    else if (small) parts.push('small');
     parts.push(license);
 
     result.artifact = parts.join('-');
@@ -218,7 +219,8 @@ function resolveConfig({appRoot, platform, architecture}) {
 
   const arch = targetArchitecture || 'x86_64';
   const parts = ['bundle', currentType, targetPlatform, arch, 'shared'];
-  if (type !== 'debug' && small) parts.push('small');
+  if (type === 'debug') parts.push('debug');
+  else if (small) parts.push('small');
   parts.push(license);
 
   result.artifact = parts.join('-');

--- a/react-native/src/NativeFFmpegKitExtended.ts
+++ b/react-native/src/NativeFFmpegKitExtended.ts
@@ -1,7 +1,8 @@
 /**
  * Low-level React Native TurboModule contract generated into each platform.
  *
- * The interface intentionally transports only scalar values and JSON strings.
+ * The interface keeps structured session/result payloads as JSON strings while
+ * allowing pre-tokenized FFmpeg/FFplay arguments to cross as string arrays.
  * Most applications should use the higher-level exported classes, which create
  * typed sessions, poll callbacks, enforce queue limits, release native handles,
  * and parse media information. Direct calls require the caller to preserve
@@ -19,9 +20,15 @@ export interface Spec extends TurboModule {
 
   /** Session creation/execution methods. Commands omit executable names. */
   createFFmpegSession(command: string): Double;
+  /** Creates an FFmpeg session from pre-tokenized arguments. */
+  createFFmpegSessionFromArguments(arguments_: ReadonlyArray<string>): Double;
   createFFprobeSession(command: string): Double;
   createFFplaySession(command: string): Double;
+  /** Creates an FFplay session from pre-tokenized arguments. */
+  createFFplaySessionFromArguments(arguments_: ReadonlyArray<string>): Double;
   createMediaInformationSession(command: string): Double;
+  /** Creates the standard media-information probe without command-string reparsing. */
+  createMediaInformationSessionFromPath(path: string): Double;
   executeSessionAsync(sessionId: Double, timeoutMs: Double): void;
   cancelSession(sessionId: Double): void;
 

--- a/react-native/src/arguments.ts
+++ b/react-native/src/arguments.ts
@@ -1,71 +1,54 @@
 /**
  * Formats an argv-style array as one FFmpegKit command string.
  *
- * Use this when arguments are already separated by your application. Values
- * containing whitespace, quotes, or backslashes are quoted and escaped so they
- * remain one token when FFmpegKit parses the command. This does not invoke the
- * device shell and does not perform shell expansion, environment substitution,
- * globbing, pipes, or redirection.
- *
- * @param arguments_ Arguments in the same order they would appear in `argv`.
- * @returns A command string suitable for `FFmpegKit.createSession()` or
- * `FFmpegKit.executeAsync()`.
- *
- * @example
- * ```ts
- * argumentsToString(['-i', '/media/My Clip.mp4', '-c:v', 'libx264']);
- * // -i "/media/My Clip.mp4" -c:v libx264
- * ```
+ * This representation is intended for display and compatibility string APIs.
+ * Prefer argument-array session constructors when arguments are already
+ * tokenized. Values requiring grouping are single-quoted so backslashes and
+ * double quotes remain literal. Embedded single quotes are emitted as adjacent
+ * quoted/unquoted segments that the native compatibility parser round-trips.
  */
 export function argumentsToString(arguments_: readonly string[]): string {
   return arguments_.map(quoteArgument).join(' ');
 }
 
 /**
- * Splits an FFmpegKit command string into argument tokens.
+ * Splits an FFmpegKit compatibility command string into argument tokens.
  *
- * Single and double quotes group whitespace. Backslashes escape the following
- * character except inside single quotes. Quote characters are removed from the
- * returned values. The parser is intentionally platform-neutral and does not
- * attempt to emulate Bash, PowerShell, `cmd.exe`, or any other shell.
- *
- * @param command FFmpeg/FFprobe/FFplay command text without the executable name.
- * @returns Parsed arguments. Blank or whitespace-only input returns an empty
- * array.
- *
- * @example
- * ```ts
- * parseArguments('-i "My Clip.mp4" -map 0:v:0');
- * // ['-i', 'My Clip.mp4', '-map', '0:v:0']
- * ```
+ * Single and double quotes group whitespace. Ordinary backslashes are literal
+ * so Windows drive and UNC paths survive unchanged. A backslash only escapes a
+ * quote, or unquoted whitespace. Empty quoted arguments are preserved.
  */
 export function parseArguments(command: string): string[] {
   const result: string[] = [];
   let current = '';
   let quote: '"' | "'" | undefined;
-  let escaped = false;
   let tokenStarted = false;
 
-  for (const char of command) {
-    if (escaped) {
-      current += char;
-      escaped = false;
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i];
+
+    if (quote === "'") {
+      if (char === "'") quote = undefined;
+      else current += char;
       tokenStarted = true;
       continue;
     }
 
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      tokenStarted = true;
-      continue;
+    if (char === '\\' && i + 1 < command.length) {
+      const next = command[i + 1];
+      const escapedQuote = next === '"' || (!quote && next === "'");
+      const escapedWhitespace = !quote && /\s/.test(next);
+      if (escapedQuote || escapedWhitespace) {
+        current += next;
+        tokenStarted = true;
+        i += 1;
+        continue;
+      }
     }
 
     if (quote) {
-      if (char === quote) {
-        quote = undefined;
-      } else {
-        current += char;
-      }
+      if (char === quote) quote = undefined;
+      else current += char;
       tokenStarted = true;
       continue;
     }
@@ -89,13 +72,12 @@ export function parseArguments(command: string): string[] {
     tokenStarted = true;
   }
 
-  if (escaped) current += '\\';
   if (tokenStarted) result.push(current);
   return result;
 }
 
 function quoteArgument(value: string): string {
-  if (value.length === 0) return '""';
-  if (!/[\s"'\\]/.test(value)) return value;
-  return `"${value.replace(/(["\\])/g, '\\$1')}"`;
+  if (value.length === 0) return "''";
+  if (!/[\s"']/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/react-native/src/ffmpeg-kit.ts
+++ b/react-native/src/ffmpeg-kit.ts
@@ -34,7 +34,11 @@ export class FFmpegKit {
    * This avoids manual quoting for paths and values containing whitespace.
    */
   static createSessionFromArguments(arguments_: readonly string[]): FFmpegSession {
-    return this.createSession(argumentsToString(arguments_));
+    if (arguments_.length === 0) throw new Error('arguments must not be empty');
+    return new FFmpegSession(
+      NativeFFmpegKitExtended.createFFmpegSessionFromArguments(arguments_),
+      argumentsToString(arguments_),
+    );
   }
 
   /**

--- a/react-native/src/ffplay-kit.ts
+++ b/react-native/src/ffplay-kit.ts
@@ -1,4 +1,5 @@
 import NativeFFmpegKitExtended from './NativeFFmpegKitExtended';
+import {argumentsToString} from './arguments';
 import {FFplaySession} from './session';
 import type {ExecuteOptions} from './types';
 
@@ -24,6 +25,19 @@ export class FFplayKit {
     return new FFplaySession(
       NativeFFmpegKitExtended.createFFplaySession(command),
       command,
+      timeoutMs,
+    );
+  }
+
+  /** Creates a playback session from pre-tokenized FFplay arguments. */
+  static createSessionFromArguments(
+    arguments_: readonly string[],
+    timeoutMs = 500,
+  ): FFplaySession {
+    if (arguments_.length === 0) throw new Error('arguments must not be empty');
+    return new FFplaySession(
+      NativeFFmpegKitExtended.createFFplaySessionFromArguments(arguments_),
+      argumentsToString(arguments_),
       timeoutMs,
     );
   }

--- a/react-native/src/ffprobe-kit.ts
+++ b/react-native/src/ffprobe-kit.ts
@@ -61,9 +61,9 @@ export class FFprobeKit {
     timeoutMs = 500,
   ): MediaInformationSession {
     requireCommand(path);
-    const command = `${MEDIA_INFO_COMMAND} ${quoteMediaPath(path)}`;
+    const command = `${MEDIA_INFO_COMMAND} ${formatMediaPathForDisplay(path)}`;
     return new MediaInformationSession(
-      NativeFFmpegKitExtended.createMediaInformationSession(command),
+      NativeFFmpegKitExtended.createMediaInformationSessionFromPath(path),
       command,
       timeoutMs,
     );
@@ -102,6 +102,8 @@ function requireCommand(command: string): void {
   if (!command.trim()) throw new Error('command must not be blank');
 }
 
-function quoteMediaPath(path: string): string {
-  return /\s/.test(path) ? `"${path.replace(/(["\\])/g, '\\$1')}"` : path;
+function formatMediaPathForDisplay(path: string): string {
+  return /[\s"\\]/.test(path)
+    ? `"${path.replace(/(["\\])/g, '\\$1')}"`
+    : path;
 }

--- a/react-native/tests/arguments.test.js
+++ b/react-native/tests/arguments.test.js
@@ -25,29 +25,42 @@ test('parseArguments handles escaped whitespace and quotes', () => {
 
 test('parseArguments preserves empty quoted arguments', () => {
   assert.deepEqual(parseArguments('ffmpeg "" tail'), ['ffmpeg', '', 'tail']);
+  assert.deepEqual(parseArguments("ffmpeg '' tail"), ['ffmpeg', '', 'tail']);
 });
 
-test('parseArguments preserves a trailing escape character', () => {
-  assert.deepEqual(parseArguments('value\\'), ['value\\']);
-});
-
-test('argumentsToString leaves simple arguments unquoted', () => {
-  assert.equal(argumentsToString(['-i', 'input.mp4']), '-i input.mp4');
-});
-
-test('argumentsToString quotes and escapes special characters', () => {
-  assert.equal(
-    argumentsToString(['input file.mp4', 'a"b', 'c\\d', '']),
-    '"input file.mp4" "a\\\"b" "c\\\\d" ""',
+test('parseArguments preserves Windows and UNC path backslashes', () => {
+  assert.deepEqual(
+    parseArguments('-i "C:\\Program Files\\Media\\clip.mp4"'),
+    ['-i', 'C:\\Program Files\\Media\\clip.mp4'],
+  );
+  assert.deepEqual(
+    parseArguments('\\\\server\\share\\clip.mp4'),
+    ['\\\\server\\share\\clip.mp4'],
   );
 });
 
-test('argumentsToString round-trips supported argument forms', () => {
+test('argumentsToString leaves simple arguments and backslashes unquoted', () => {
+  assert.equal(argumentsToString(['-i', 'input.mp4', 'c\\d']), '-i input.mp4 c\\d');
+});
+
+test('argumentsToString safely quotes special values', () => {
+  assert.equal(
+    argumentsToString(['input file.mp4', 'a"b', "single'value", '']),
+    `'input file.mp4' 'a"b' 'single'\\''value' ''`,
+  );
+});
+
+test('argumentsToString round-trips Windows paths, quotes, and empty values', () => {
   const values = [
     '-filter_complex',
     '[0:v]scale=1280:720[out v]',
     'quote"value',
+    "single'value",
     'slash\\value',
+    'C:\\Program Files\\Media\\clip.mp4',
+    'C:\\Program Files\\Media\\',
+    'quote"and\\',
+    '\\\\server\\share\\folder with spaces\\',
     '',
   ];
 

--- a/react-native/windows/FFmpegKitExtended/FFmpegKitExtended.cpp
+++ b/react-native/windows/FFmpegKitExtended/FFmpegKitExtended.cpp
@@ -67,6 +67,12 @@ double FFmpegKitExtended::createFFmpegSession(std::string command) noexcept {
   return invoke<double>("createFFmpegSession", [&] { return api::createFFmpegSession(command); });
 }
 
+double FFmpegKitExtended::createFFmpegSessionFromArguments(std::vector<std::string> arguments) noexcept {
+  return invoke<double>("createFFmpegSessionFromArguments", [&] {
+    return api::createFFmpegSessionFromArguments(arguments);
+  });
+}
+
 double FFmpegKitExtended::createFFprobeSession(std::string command) noexcept {
   return invoke<double>("createFFprobeSession", [&] { return api::createFFprobeSession(command); });
 }
@@ -75,8 +81,20 @@ double FFmpegKitExtended::createFFplaySession(std::string command) noexcept {
   return invoke<double>("createFFplaySession", [&] { return api::createFFplaySession(command); });
 }
 
+double FFmpegKitExtended::createFFplaySessionFromArguments(std::vector<std::string> arguments) noexcept {
+  return invoke<double>("createFFplaySessionFromArguments", [&] {
+    return api::createFFplaySessionFromArguments(arguments);
+  });
+}
+
 double FFmpegKitExtended::createMediaInformationSession(std::string command) noexcept {
   return invoke<double>("createMediaInformationSession", [&] { return api::createMediaInformationSession(command); });
+}
+
+double FFmpegKitExtended::createMediaInformationSessionFromPath(std::string path) noexcept {
+  return invoke<double>("createMediaInformationSessionFromPath", [&] {
+    return api::createMediaInformationSessionFromPath(path);
+  });
 }
 
 void FFmpegKitExtended::executeSessionAsync(double sessionId, double timeoutMs) noexcept {

--- a/react-native/windows/FFmpegKitExtended/FFmpegKitExtended.h
+++ b/react-native/windows/FFmpegKitExtended/FFmpegKitExtended.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace winrt::FFmpegKitExtended {
 
@@ -41,14 +42,23 @@ struct FFmpegKitExtended {
   REACT_SYNC_METHOD(createFFmpegSession)
   double createFFmpegSession(std::string command) noexcept;
 
+  REACT_SYNC_METHOD(createFFmpegSessionFromArguments)
+  double createFFmpegSessionFromArguments(std::vector<std::string> arguments) noexcept;
+
   REACT_SYNC_METHOD(createFFprobeSession)
   double createFFprobeSession(std::string command) noexcept;
 
   REACT_SYNC_METHOD(createFFplaySession)
   double createFFplaySession(std::string command) noexcept;
 
+  REACT_SYNC_METHOD(createFFplaySessionFromArguments)
+  double createFFplaySessionFromArguments(std::vector<std::string> arguments) noexcept;
+
   REACT_SYNC_METHOD(createMediaInformationSession)
   double createMediaInformationSession(std::string command) noexcept;
+
+  REACT_SYNC_METHOD(createMediaInformationSessionFromPath)
+  double createMediaInformationSessionFromPath(std::string path) noexcept;
 
   REACT_METHOD(executeSessionAsync)
   void executeSessionAsync(double sessionId, double timeoutMs) noexcept;


### PR DESCRIPTION
Fixes #38.

Depends on native PR: https://github.com/akashskypatel/ffmpeg-kit-builders/pull/72

## Changes

### Flutter
- add the native `media_information_create_session_from_argv` FFI binding
- add `MediaInformationSession.fromArguments(List<String>)` and `createWithArguments(List<String>)`
- route media-information file/URI helpers through argv-safe argument passing
- add `FFplaySession.fromArguments` / `createFromArguments` and an `FFplayKit.createSessionFromArguments` factory
- keep existing string-command constructors for compatibility
- the existing `FFmpegSession.fromArguments` becomes end-to-end argv-safe with native PR #72

### React Native
- route media-information path helpers through a path-specific native method backed by `media_information_create_session_from_argv`
- transport pre-tokenized FFmpeg and FFplay arguments across the TurboModule as string arrays instead of serializing them back into command text
- call `ffmpeg_kit_create_session_from_argv` and `ffplay_kit_create_session_from_argv` directly from the shared C++ bridge
- wire the new argv methods through the cross-platform C++ TurboModule implementation and React Native Windows bridge
- keep raw string-command APIs as compatibility APIs
- align JS compatibility parsing/formatting with the native parser: preserve empty values, Windows/UNC backslashes, trailing backslashes, whitespace, and literal quote characters
- use argument serialization for diagnostic/session command display only, never as the transport for an argv session

## Why

The wrapper APIs exposed argument-list helpers, but React Native FFmpeg converted those arrays back into command text, FFplay lacked an argv helper, and the native execution layer reparsed argv sessions. Together with the FFprobe defect from #38, this meant pre-tokenized values could still change meaning before reaching FFmpeg/FFprobe/FFplay.

With native PR #72, argv remains argv end-to-end. Compatibility command strings remain supported for callers that intentionally use them.
